### PR TITLE
Added Galician translation

### DIFF
--- a/addon/doc/es/readme.md
+++ b/addon/doc/es/readme.md
@@ -1,4 +1,4 @@
-#Complemento de Lambda para NVDA#
+﻿#Complemento de Lambda para NVDA#
 
 lambda-nvda ha sido escrito por alberto Zanella.
 
@@ -7,7 +7,7 @@ Puede encontrar más información sobre este complemento en: https://github.com/
 Este proyecto es un módulo de aplicación para el software Lambda. Ha sido inspirado por el trabajo de Peter Lecky en la Comenius University.
 LAMBDA (Linear Access to Mathematic for Braille Device and Audio-synthesis, acceso lineal a las matemáticas mediante pantallas braille y síntesis de audio) es un programa que ayuda a las personas ciegas a leer y escribir matemáticas usando una pantalla braile y/o un sintetizador de audio.
 LAMBDA es el resultado de un proyecto EU. Para más información acerca de LAMBDA por favor visite [http://www.lambdaproject.org/](http://www.lambdaproject.org/).  
-La versión actual de este complemento tiene tablas braille solo para el idioma italiano pero su interfaz está disponible tanto en el idioma italiano como en español ahora mismo.
+La versión actual de este complemento tiene tablas braille solo para el idioma italiano pero su interfaz está disponible tanto en el idioma italiano como en español, inglés y gallego ahora mismo.
 Si es usted un usuario no italiano de LAMBDA y le gustaría contribuír con traducciones en su idioma, siéntase libre de contactar al autor (consulte más abajo) o bifurcar este proyecto.
 
 **Nota:** Este complemento ha sido desarrollado por Alberto Zanella como una actividad voluntaria. Ni el autor ni los contribuyentes están relacionados con la venta o el desarrollo del programa LAMBDA. si quisiera obtener más información sobre LAMBDA, reportar problemas u obtener soporte, por favor contacte con su distribuidor local (en España, ONCE-CIDAT). Si está encontrando dificultades usando o instalando este complemento, por favor contacte con el autor o use el enlace "Issues" (errores) disponible en la página del proyecto en Github.

--- a/addon/doc/es/readme.md
+++ b/addon/doc/es/readme.md
@@ -1,4 +1,4 @@
-
+﻿
 # Complemento de Lambda para NVDA
 
 lambda-nvda ha sido escrito por alberto Zanella.
@@ -13,6 +13,10 @@ La versión actual de este complemento tiene tablas braille solo para el idioma 
 Si es usted un usuario no italiano de LAMBDA y le gustaría contribuír con traducciones en su idioma, siéntase libre de contactar al autor (consulte más abajo) o bifurcar este proyecto.
 
 **Nota:** Este complemento ha sido desarrollado por Alberto Zanella como una actividad voluntaria. Ni el autor ni los contribuyentes están relacionados con la venta o el desarrollo del programa LAMBDA. si quisiera obtener más información sobre LAMBDA, reportar problemas u obtener soporte, por favor contacte con su distribuidor local (en España, ONCE-CIDAT). Si está encontrando dificultades usando o instalando este complemento, por favor contacte con el autor o use el enlace "Issues" (errores) disponible en la página del proyecto en Github.
+
+## Demostración en audio
+
+Si desea oír este complemento en acción le recomendamos escuchar la audiodemostración realizada por Salva Doménech para la lista "LAMBDA with NVDA", en el siguiente enlace: [https://drive.google.com/file/d/0B8k1H5BNRE0BY2JQNjRlVWFtV2s/view?usp=sharing] Esta demostración cubre la instalación del complemento, la escritura y verbalización de las acciones más frecuentes en LAMBDA y la explicación del soporte Braille, aún en desarrollo para el idioma español.
 
 ## Características del complemento
 

--- a/addon/doc/gl/readme.md
+++ b/addon/doc/gl/readme.md
@@ -1,0 +1,79 @@
+﻿#Complemento de Lambda para NVDA#
+
+Este proxecto é un módulo de aplicación para a aplicación Lambda. foi inspirado polo traballo de Peter Lecky na Comenius University.
+LAMBDA (Linear Access to Mathematic for Braille Device and Audio-synthesis, acceso lineal ás matemáticas mediante pantallas braille e síntesis de fala) é un programa que axuda ás persoas cegas a eer e escribir matemáticas utilizando unha pantalla braile e/ou un sintetizador de audio.
+LAMBDA é o resultado dun proxecto EU. Para máis información acerca de LAMBDA por favor visite [http://www.lambdaproject.org/](http://www.lambdaproject.org/).  
+A versión actual deste complemento ten táboas braille só para a lingua italiana pero a súa interface está dispoñible tanto na lingua italiana coma en castelán, inglés e galego agora mesmo.
+Si é vostede un usuario non italiano de LAMBDA e gostaríalle contribuír con traducións na súa lingua, síntase libre de contactar ao autor (consulte embaixo) ou bifurcar este proxecto.
+
+**Nota:** Este complemento foi desenvolvido por Alberto Zanella como unha actividade voluntaria. Nin o autor nin os contribuíntes están relacionados coa venda ou co desenvolvemento do programa LAMBDA. Se quixese obter máis información sobre LAMBDA, reportar problemas ou obter soporte, por favor contacte co seu distribuidor local (en España, ONCE-CIDAT). Se está atopando dificultades usando ou instalando este complemento, por favor contacte co autor ou utilice a liga "Issues" (erros) dispoñible na páxina do proxecto en Github.
+
+##Características do complemento
+
+###Soporte para fala:
+
+* Infórmase dos menús e diálogos correctamente;
+* Soporte para fala natural das fórmulas matemáticas utilizando o motor interno de LAMBDA (p.ex. "raíz composta 3 de raíz composta 3 x máis 24, fin da raíz, menos 3 igual 0");
+* Lectura por carácter, palabra, liña e Verbalizar Todo implementada.
+* Fala cando un bloque de texto está seleccionado ou é estendido  (utilizando CTRL+B e SHIFT+CTRL+B);
+* Fala ao moverse polo texto con comandos de Windows e con comandos específicos do Lambda;
+* Tanto o modo de fala curto coma o estendido están soportados (pode establecelo utilizando o menú Ferramentas de LAMBDA);
+* Xanelas de diálogos especiais como a do modo estrutura, a calculadora, e a de matriz son agora correctamente reportadas e NVDA le correctamente ao mover o cursor por elas ou ao introducir texto;
+* O eco de escritura utiliza o procesador de texto de Lambda, de xeito que se informará correctamente de símbolos e marcadores serán.
+
+###Soporte para Braille:
+
+*O complemento instala (dentro do directorio de perfil de usuario) e activa un perfil de NVDA cunha táboa braille. Esta táboa pode diferir entre distintas linguas. A táboa foi construída dende a presente nos scripts de Jaws para LAMBDA (arquivo jbt). Entón os símbolos e marcadores son representados mediante os mesmos patróns de puntos;
+* O complemento crea un perfil de configuración e establece a configuración de braille estándar. De xeito que a saída á táboa braille personalizada só está establecida cando LAMBDA está activo;
+* Os diálogos e menús son correctamente braillificados;
+* O contido do editor é correctamente adaptado para braille e o usuario pode moverse usando as teclas de desprazamento braille e de ruta do cursor;
+* comezando na versión del complemento 1.1.0 existen dúas formas nas cales o contido é representado: "Modo plano" e "Modo non plano". Cando o "Modo plano" está activado, NVDA utilizará o Modelo de Mostrado para obter o contido dende Lambda e para determinar a posición do cursor braille. Isto é especialmente beneficioso cando o usuario necesita moverse pola pantalla, incluso polos espazos en branco do editor. Cando o "Modo plano" está estabelecido a "Desactivado", a representación do texto na pantalla braille é máis estable, xa que NVDA utiliza Windows API para obtela. De xeito que, cando o usuario se move entre espazos en branco o cursor na pantalla braille non seguirá ao cursor real ata que un espazo non en branco sexa inxerido polo usuario. 
+
+O "Modo plano" está activo por defecto. Pode alternar o "Modo plano" entre activado e desactivado premendo NVDA+SHIFT+F.
+
+Recoméndase encarecidamente deshabilitar o "Modo plano" cando se utilice DPI personalizado en Windows (opción de Tamano personalizado), e especialmente cando se ten unha configuración de pantalla de máis de 96 DPI (máis longo que 100%).
+* A estrutura dos cadros de diálogo é máis sinxela, eliminando información repetida;
+* A selección é marcada correctamente utilizando os puntos 7 e 8, e correctamente refrescada ao premer comandos estándar de Windows (SHIFT+FRECHAS) ou comandos específicos de Lambda (CTRL+B, CTRL+SHIFT+B).
+
+##Antes de empezar a usar este complemento.
+Este complemento crea un perfil de NVDA nomeado como "lambda" que está asociado coa aplicación lambda.exe. Este perfil está configurado con todas as opcións no que ás opcións braille, á táboa braille personalizada, á localización do foco e ás opcións do modo plano se refire.
+
+
+Se un perfil previamente existente co mesmo nome está presente no seu sistema, non será sobrescrito e deberá axustar manualmente o perfil de configuración.
+
+Para saír desta situación, despois da instalación do complemento suxerimos o borrado de vellas versións do perfil "lambda". Para facer isto, abra o menú de NVDA, seleccione o elemento de menú "Configuración de perfís" e prema ENTER.
+
+No diálogo de Configuración de perfís, poderá localizar e borrar o perfil "lambda". O perfil será criado novamente a vindeira vez que se inicie Lambda.
+
+Eliminar o perfil "lambda" debería de ser unha solución fácil tamén cando atope algún fallo que "apareza" nalgún punto mentres se utilice o complemento. Por exemplo, se a táboa braille non está correctamente estabelecida, no lugar de configurar manualmente o perfil pode simplemente borralo. O complemento criará un novo a vindeira vez que abra o editor Lambda.
+
+Cada vez que o editor Lambda é arrincado, o complemento verifica se existe un perfil co nome "lambda". Se non existe crea automaticamente un perfil coa seguinte forma:
+
+```
+Nombre del fichero: userData\profiles\lambda.ini :
+
+[braille]
+	readByParagraph = False
+	tetherTo = focus
+	translationTable = path-to-the-addon-brailleTable-dir\tableName
+
+[lambda]
+	brailleFlatMode = True
+
+ ```
+
+Onde :
+* path-to-the-addon-brailleTable-dir : É a ruta absoluta do directorio do complemento + "\brailleTables"
+* tableName : Depende do idioma seleccionado. Actualmente a tabla braille italiana, "lambda-ita.utb" , está presente.
+
+
+
+#Autores y Contribuyentes:
+* Autor: Alberto Zanella <lapostadi[omeuprimeironome]@gmail.com>
+* Iván Novegil
+* Noelia Ruiz Martínez
+* Alessandro Albano
+* Christian Leo
+
+
+

--- a/addon/locale/gl/LC_MESSAGES/nvda.po
+++ b/addon/locale/gl/LC_MESSAGES/nvda.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 'Lambda' '1.1.4'\n"
 "POT-Creation-Date: 2017-05-10 09:09+0200\n"
-"PO-Revision-Date: 2017-05-10 09:21+0200\n"
+"PO-Revision-Date: 2017-05-15 13:26+0200\n"
 "Last-Translator: Iván Novegil Cancelas <info@inovegil.site40.net>\n"
 "Language-Team: Iván Novegil Cancelas <info@inovegil.site40.net>\n"
 "Language: gl\n"
@@ -110,7 +110,7 @@ msgstr ""
 
 #: buildVars.py:17
 msgid "Lambda math editor addon"
-msgstr "Complemento para o editor matemático Lambda"
+msgstr "Lambda (editor matemático) coma complemento para NVDA"
 
 #: buildVars.py:20
 msgid ""

--- a/addon/locale/gl/LC_MESSAGES/nvda.po
+++ b/addon/locale/gl/LC_MESSAGES/nvda.po
@@ -1,0 +1,139 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: 'Lambda' '1.1.4'\n"
+"POT-Creation-Date: 2017-05-10 09:09+0200\n"
+"PO-Revision-Date: 2017-05-10 09:21+0200\n"
+"Last-Translator: Iván Novegil Cancelas <info@inovegil.site40.net>\n"
+"Language-Team: Iván Novegil Cancelas <info@inovegil.site40.net>\n"
+"Language: gl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.8\n"
+"X-Poedit-Basepath: ../../../..\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-SearchPath-0: addon\n"
+"X-Poedit-SearchPath-1: buildVars.py\n"
+
+#: addon/appModules/lambda/lambdaEdit.py:80
+msgid "Reports the current line under the application cursor."
+msgstr "Informa da liña actual baixo o cursor da aplicación."
+
+#: addon/appModules/lambda/lambdaEdit.py:86
+msgid "reads from the beginning of the document up to the end of the text."
+msgstr "lee dende o comezo do documento ata o final do texto."
+
+#: addon/appModules/lambda/lambdaEdit.py:92
+msgid "Announces the current selection in edit controls and documents."
+msgstr "Anuncia a selección actual en controis de edición e documentos."
+
+#: addon/appModules/lambda/lambdaEdit.py:235
+msgid ""
+"Extends the selection to the surrounding block and reads it. If used with "
+"shift key, reduce the block and read it."
+msgstr ""
+"Estende a selección ao bloque do redor e leo. Se é usado ca tecla shift, "
+"reduce o bloque e fálao."
+
+#: addon/appModules/lambda/lambdaEdit.py:244
+msgid "Duplicates the current line and reads it"
+msgstr "Duplica a liña actual e lea"
+
+#: addon/appModules/lambda/lambdaEdit.py:249
+msgid "flat mode "
+msgstr "modo plano "
+
+#: addon/appModules/lambda/lambdaEdit.py:255
+msgid "Toggle the braille flat mode on or off."
+msgstr "Cnmuta o modo plano do braille entre activado e desactivado."
+
+#: addon/appModules/lambda/lambdaProfileSetup.py:16
+msgid "lambda-ita.utb"
+msgstr ""
+
+#: addon/appModules/lambda/sharedMessages/__init__.py:8
+msgid "selected"
+msgstr "seleccionado"
+
+#: addon/appModules/lambda/sharedMessages/__init__.py:9
+msgid "not selected"
+msgstr "non seleccionado"
+
+#: addon/appModules/lambda/sharedMessages/__init__.py:10
+msgid "on"
+msgstr "activado"
+
+#: addon/appModules/lambda/sharedMessages/__init__.py:11
+msgid "off"
+msgstr "desactivado"
+
+#: addon/installTasks.py:17
+msgid "Incompatible version of the addon detected"
+msgstr "Versión incompatible do complemento detectada"
+
+#: addon/installTasks.py:20
+msgid ""
+"An old, incompatible version of this addon has been detected.\n"
+"This prevents the installation to be completed.\n"
+"Please uninstall the previous version before proceeding with the Lambda "
+"addon setup.\n"
+msgstr ""
+"Unha versión vella e incompatible deste complemento foi detectada.\n"
+"Isto impide que a instalación sexa completada.\n"
+"Pregámoslle desinstale a versión vella antes de proceder coa instalación do "
+"complemento Lambda.\n"
+
+#: addon/installTasks.py:26
+msgid "lambda profile already exists"
+msgstr "Perfil lambda xa existe"
+
+#: addon/installTasks.py:29
+msgid ""
+"Another profile named \"lambda\" is already present in your NVDA "
+"configuration. \n"
+"This prevents the addon on create and configure the lambda profile "
+"correctly.\n"
+"If you want the addon to configure a lambda profile for you, please delete "
+"the old one named \"lambda\" using the NVDA \"Configuration Profiles\" "
+"dialog.\n"
+"The new profile will be created the next time you'll start the Lambda app.\n"
+"Otherwise please edit your profile configuration file manually.\n"
+msgstr ""
+"Outro perfil chamado \"lambda\" está presente na configuración do NVDA.\n"
+"Isto impide ao complemento criar e configurar o perfil \"lambda\" "
+"correctamente.\n"
+"Se desexa que o complemento configure un novo perfil \"lambda\", pregámosle "
+"borre o vello perfil \"lambda\" dende o diálogo \"Configuración de perfís"
+"\".\n"
+"O novo perfil será criado a vindeira vez que reinicie a app Lambda.\n"
+"Doutro xeito edite o arquivo do Perfil de configuración a man.\n"
+
+#: buildVars.py:17
+msgid "Lambda math editor addon"
+msgstr "Complemento para o editor matemático Lambda"
+
+#: buildVars.py:20
+msgid ""
+"This addon provides access to the Lambda math editor with both braille and "
+"speech support."
+msgstr ""
+"Este complemento proporciona o acceso ao editor Lambda con soporte para "
+"braille e fala."
+
+#~ msgid ""
+#~ "An older version of this addon has been detected.\n"
+#~ "This prevents the installation to be completed.\n"
+#~ "Please uninstall the previous version before proceeding with the Lambda "
+#~ "addon setup.\n"
+#~ msgstr ""
+#~ "Una versión antigua de este complemento ha sido detectada.\n"
+#~ "Esto impide que la instalación sea completada.\n"
+#~ "Por favor desinstale la vieja versión antes de proceder con la "
+#~ "instalación del complemento Lambda.\n"
+
+#~ msgid ""
+#~ "Announces the current selection in edit controls and documents. If there "
+#~ "is no selection it says so."
+#~ msgstr ""
+#~ "Anuncia la selección actual en controles de edición y documentos. Si no "
+#~ "hay selección lo habla."

--- a/readme-src.md
+++ b/readme-src.md
@@ -1,9 +1,9 @@
-#Lambda Add-On for NVDA
+﻿#Lambda Add-On for NVDA
 
 This project is an appModule for the LAMBDA Software. It has been inspired by the work of Peter Lecky at the Comenius University. 
 LAMBDA (Linear Access to Mathematic for Braille Device and Audio-synthesis) is a software that helps blind people to read and write math using a braille display and/or a speech synthesizer.
 LAMBDA is the result of an EU-Project. For more information about LAMBDA please visit [http://www.lambdaproject.org/](http://www.lambdaproject.org/).  
-The current version of the addon has braille tables for the Italian language only but its interface is available both in Italian and Spanish right now.
+The current version of the addon has braille tables for the Italian language only but its interface is available both in Italian and Spanish, English and Galician right now.
 If you are a non-italian user of LAMBDA and you would like to contribute with translations in your language, feel free to contact the author (see below) or fork this project.
 
 **Please note:** This addon has been developed by Alberto Zanella as a voluntary activity. Nor the author or the contributors are involved in selling and / or development of the software Lambda. If you need more information about Lambda, or you need support on how to use it, please contact your local distributor. If you are encountering any difficulties when using or installing this addon, please contact the author or use the "Issues" link on the Github project page.


### PR DESCRIPTION
Added Galician translation. I'm trying to arrange with the current translator the transference to the official SVM if the addon is included on the NVDA official addons website. I'll maintain you up to date with the result of this by the list.
Shortly I'm having the audiodemo in Galician and I'm adding the audiodemo by Salva Doménech to the Spanish doc.

Any problem, comment.