### PR TITLE
Updated Spanish and galician translations, and added details on how to succesfully open the Reversion Wizard

### DIFF
--- a/addon/doc/es/readme.md
+++ b/addon/doc/es/readme.md
@@ -50,7 +50,9 @@ Este complemento crea un perfil de NVDA nombrado como "lambda" que está asociad
 
 Si un perfil previamente existente con el mismo nombre está presente en su sistema, no será sobreescrito y deberá ajustar manualmente el perfil de configuración.
 
-Para salir de esta situación, después de la instalación del complemento sugerimos el borrado de viejas versión del perfil "lambda". Para hacer esto, abra el menú de NVDA, seleccione el elemento de menú "Perfiles de configuración" y pulse ENTER.
+Para salir de esta situación, si tiene configuraciones espcíficas que le gustaría preservar, puede usar el "Asistente de Reversión del perfil LAMBDA". La tecla rápida para abrir esta herramienta es NVDA+alt+r (cuando se está dentro de LAMBDA).
+
+Una opción fácil es también borrar viejas versiones del perfil "lambda" después de la instalación del complemento. Para hacer esto, abra el menú de NVDA, seleccione el elemento de menú "Perfiles de configuración" y pulse ENTER.
 
 En el diálogo de Perfiles de configuración, podrá localizar y borrar el perfil "lambda". El perfil será creado nuevamente la próxima vez que se inicie Lambda.
 
@@ -74,6 +76,11 @@ Nombre del fichero: userData\profiles\lambda.ini :
 Where :
 * path-to-the-addon-brailleTable-dir : Es la ruta absoluta del directorio del complemento + "\brailleTables"
 * tableName : Depende del idioma seleccionado. Actualmente la tabla braille italiana, "lambda-ita.utb" , está presente.
+
+## Teclas Rápidas del Complemento
+
+* **NVDA+Shift+f**: Alterna el modo plano de braille entre activado y desactivado;
+* **NVDA+alt+r**: Abre el "Asistente de Reversión del Perfil LAMBDA".
 
 
 

--- a/addon/doc/gl/readme.md
+++ b/addon/doc/gl/readme.md
@@ -41,7 +41,9 @@ Este complemento crea un perfil de NVDA nomeado como "lambda" que está asociado
 
 Se un perfil previamente existente co mesmo nome está presente no seu sistema, non será sobrescrito e deberá axustar manualmente o perfil de configuración.
 
-Para saír desta situación, despois da instalación do complemento suxerimos o borrado de vellas versións do perfil "lambda". Para facer isto, abra o menú de NVDA, seleccione o elemento de menú "Configuración de perfís" e prema ENTER.
+Para saír desta situación, se ten configuracións espcíficas que lle gostaría preservar, pode utilizar o "Asistente de Reversión do perfil LAMBDA". O atallo para abrir esta ferramenta é NVDA+alt+r (cando se está dentro de LAMBDA).
+
+Unha opción fácil é tamén borrar vellas versións do perfil "lambda" despois da instalación do complemento. Para facer isto, abra o menú de NVDA, seleccione o elemento de menú "Configuración de perfís" e prema ENTER.
 
 No diálogo de Configuración de perfís, poderá localizar e borrar o perfil "lambda". O perfil será criado novamente a vindeira vez que se inicie Lambda.
 
@@ -66,6 +68,10 @@ Onde :
 * path-to-the-addon-brailleTable-dir : É a ruta absoluta do directorio do complemento + "\brailleTables"
 * tableName : Depende do idioma seleccionado. Actualmente a tabla braille italiana, "lambda-ita.utb" , está presente.
 
+## Atallos de Teclado do Complemento
+
+* **NVDA+Shift+f**: Alterna o modo plano do braille entre activado e desactivado;
+* **NVDA+alt+r**: Abre o "Asistente de Reversión do Perfil LAMBDA".
 
 
 

--- a/addon/locale/es/LC_MESSAGES/nvda.po
+++ b/addon/locale/es/LC_MESSAGES/nvda.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 'Lambda' '1.1.4'\n"
-"POT-Creation-Date: 2017-05-10 09:09+0200\n"
-"PO-Revision-Date: 2017-05-10 12:34+0200\n"
+"POT-Creation-Date: 2017-05-17 12:15+0200\n"
+"PO-Revision-Date: 2017-05-17 12:19+0200\n"
 "Last-Translator: Iván Novegil Cancelas <info@inovegil.site40.net>\n"
 "Language-Team: Iván Novegil Cancelas <info@inovegil.site40.net>\n"
 "Language: es\n"
@@ -14,6 +14,12 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-SearchPath-0: addon\n"
 "X-Poedit-SearchPath-1: buildVars.py\n"
+
+#: addon/appModules/lambda/__init__.py:91
+msgid "Shows a dialog to revert lambda profile options to the default."
+msgstr ""
+"Muestra un diálogo para revertir las opciones del perfil LAMBDA a las de "
+"fábrica."
 
 #: addon/appModules/lambda/lambdaEdit.py:80
 msgid "Reports the current line under the application cursor."
@@ -27,29 +33,44 @@ msgstr "lee desde el comienzo del documento hasta el final del texto."
 msgid "Announces the current selection in edit controls and documents."
 msgstr "Anuncia la selección actual en controles de edición y documentos."
 
-#: addon/appModules/lambda/lambdaEdit.py:235
-msgid ""
-"Extends the selection to the surrounding block and reads it. If used with "
-"shift key, reduce the block and read it."
-msgstr ""
-"Extiende la selección al bloque de alrededor y lo lee. Si es usado con la "
-"tecla shift, reduce el bloque y lo dice."
-
-#: addon/appModules/lambda/lambdaEdit.py:244
-msgid "Duplicates the current line and reads it"
-msgstr "Duplica la línea actual y la lee"
-
-#: addon/appModules/lambda/lambdaEdit.py:249
+#: addon/appModules/lambda/lambdaEdit.py:248
 msgid "flat mode "
 msgstr "modo plano "
 
-#: addon/appModules/lambda/lambdaEdit.py:255
+#: addon/appModules/lambda/lambdaEdit.py:254
 msgid "Toggle the braille flat mode on or off."
 msgstr "Conmuta el modo plano de braille entre activado y desactivado."
 
-#: addon/appModules/lambda/lambdaProfileSetup.py:16
+#: addon/appModules/lambda/lambdaProfileSetup.py:22
 msgid "lambda-ita.utb"
 msgstr ""
+
+#: addon/appModules/lambda/lambdaProfileSetup.py:103
+msgid "Revert LAMBDA Profile Wizard"
+msgstr "Asistente de Reversión del Perfil LAMBDA"
+
+#: addon/appModules/lambda/lambdaProfileSetup.py:107
+msgid ""
+"Choose which options you want to reset to the default value for the Lambdas "
+"profile"
+msgstr "Elija cuáles de las opciones del perfil LAMBDA desea restablecer"
+
+#: addon/appModules/lambda/lambdaProfileSetup.py:112
+#, python-format
+msgid "Keep the LAMBDA braille table for the current language (%s)"
+msgstr "Mantener la tabla braille para el idioma actual (%s)"
+
+#: addon/appModules/lambda/lambdaProfileSetup.py:117
+msgid "Set the braille cursor to tether the focus"
+msgstr "Configurar el cursor braille para seguir al foco"
+
+#: addon/appModules/lambda/lambdaProfileSetup.py:122
+msgid "Disable the Braille reading by paragraph"
+msgstr "Deshabilitar la lectura braille por párrafo"
+
+#: addon/appModules/lambda/lambdaProfileSetup.py:127
+msgid "Disable word wrappping of the braille line"
+msgstr "Deshabilitar la no separación de palabras braille de una línea"
 
 #: addon/appModules/lambda/sharedMessages/__init__.py:8
 msgid "selected"
@@ -66,6 +87,16 @@ msgstr "activado"
 #: addon/appModules/lambda/sharedMessages/__init__.py:11
 msgid "off"
 msgstr "desactivado"
+
+#: addon/appModules/lambda/sharedMessages/__init__.py:12
+msgid "An NVDA settings dialog is already open. Please close it first."
+msgstr ""
+"Un diálogo de configuración de NVDA ya está abierto. Por favor ciérrelo "
+"primero."
+
+#: addon/appModules/lambda/sharedMessages/__init__.py:13
+msgid "Error"
+msgstr "Error"
 
 #: addon/installTasks.py:17
 msgid "Incompatible version of the addon detected"
@@ -120,6 +151,16 @@ msgid ""
 msgstr ""
 "Este complemento proporciona el acceso al editor Lambda con soporte para "
 "braille y habla."
+
+#~ msgid ""
+#~ "Extends the selection to the surrounding block and reads it. If used with "
+#~ "shift key, reduce the block and read it."
+#~ msgstr ""
+#~ "Extiende la selección al bloque de alrededor y lo lee. Si es usado con la "
+#~ "tecla shift, reduce el bloque y lo dice."
+
+#~ msgid "Duplicates the current line and reads it"
+#~ msgstr "Duplica la línea actual y la lee"
 
 #~ msgid ""
 #~ "An older version of this addon has been detected.\n"

--- a/addon/locale/gl/LC_MESSAGES/nvda.po
+++ b/addon/locale/gl/LC_MESSAGES/nvda.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: 'Lambda' '1.1.4'\n"
-"POT-Creation-Date: 2017-05-10 09:09+0200\n"
-"PO-Revision-Date: 2017-05-15 13:26+0200\n"
+"POT-Creation-Date: 2017-05-17 12:19+0200\n"
+"PO-Revision-Date: 2017-05-17 12:21+0200\n"
 "Last-Translator: Iván Novegil Cancelas <info@inovegil.site40.net>\n"
 "Language-Team: Iván Novegil Cancelas <info@inovegil.site40.net>\n"
 "Language: gl\n"
@@ -14,6 +14,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-SearchPath-0: addon\n"
 "X-Poedit-SearchPath-1: buildVars.py\n"
+
+#: addon/appModules/lambda/__init__.py:91
+msgid "Shows a dialog to revert lambda profile options to the default."
+msgstr ""
+"Amosa un diálogo para revertir as opcións do perfil LAMBDA ás de fábrica"
 
 #: addon/appModules/lambda/lambdaEdit.py:80
 msgid "Reports the current line under the application cursor."
@@ -27,29 +32,44 @@ msgstr "lee dende o comezo do documento ata o final do texto."
 msgid "Announces the current selection in edit controls and documents."
 msgstr "Anuncia a selección actual en controis de edición e documentos."
 
-#: addon/appModules/lambda/lambdaEdit.py:235
-msgid ""
-"Extends the selection to the surrounding block and reads it. If used with "
-"shift key, reduce the block and read it."
-msgstr ""
-"Estende a selección ao bloque do redor e leo. Se é usado ca tecla shift, "
-"reduce o bloque e fálao."
-
-#: addon/appModules/lambda/lambdaEdit.py:244
-msgid "Duplicates the current line and reads it"
-msgstr "Duplica a liña actual e lea"
-
-#: addon/appModules/lambda/lambdaEdit.py:249
+#: addon/appModules/lambda/lambdaEdit.py:248
 msgid "flat mode "
 msgstr "modo plano "
 
-#: addon/appModules/lambda/lambdaEdit.py:255
+#: addon/appModules/lambda/lambdaEdit.py:254
 msgid "Toggle the braille flat mode on or off."
 msgstr "Cnmuta o modo plano do braille entre activado e desactivado."
 
-#: addon/appModules/lambda/lambdaProfileSetup.py:16
+#: addon/appModules/lambda/lambdaProfileSetup.py:22
 msgid "lambda-ita.utb"
 msgstr ""
+
+#: addon/appModules/lambda/lambdaProfileSetup.py:103
+msgid "Revert LAMBDA Profile Wizard"
+msgstr "Asistente de Reversión do Perfil LAMBDA"
+
+#: addon/appModules/lambda/lambdaProfileSetup.py:107
+msgid ""
+"Choose which options you want to reset to the default value for the Lambdas "
+"profile"
+msgstr "Escolla cales das opcións do perfil LAMBDA desexa restablecer"
+
+#: addon/appModules/lambda/lambdaProfileSetup.py:112
+#, python-format
+msgid "Keep the LAMBDA braille table for the current language (%s)"
+msgstr "Manter a tabla braille para a lingua actual (%s)"
+
+#: addon/appModules/lambda/lambdaProfileSetup.py:117
+msgid "Set the braille cursor to tether the focus"
+msgstr "Configurar o cursor braille para seguir ó foco"
+
+#: addon/appModules/lambda/lambdaProfileSetup.py:122
+msgid "Disable the Braille reading by paragraph"
+msgstr "Deshabilitar a lectura braille por parágrafo"
+
+#: addon/appModules/lambda/lambdaProfileSetup.py:127
+msgid "Disable word wrappping of the braille line"
+msgstr "Deshabilitar a non separación de palabras braille dunha liña"
 
 #: addon/appModules/lambda/sharedMessages/__init__.py:8
 msgid "selected"
@@ -66,6 +86,16 @@ msgstr "activado"
 #: addon/appModules/lambda/sharedMessages/__init__.py:11
 msgid "off"
 msgstr "desactivado"
+
+#: addon/appModules/lambda/sharedMessages/__init__.py:12
+msgid "An NVDA settings dialog is already open. Please close it first."
+msgstr ""
+"Un diálogo de configuración de NVDA xa está aberto. Pregámoslle o peche "
+"primeiro."
+
+#: addon/appModules/lambda/sharedMessages/__init__.py:13
+msgid "Error"
+msgstr "Erro"
 
 #: addon/installTasks.py:17
 msgid "Incompatible version of the addon detected"
@@ -119,6 +149,16 @@ msgid ""
 msgstr ""
 "Este complemento proporciona o acceso ao editor Lambda con soporte para "
 "braille e fala."
+
+#~ msgid ""
+#~ "Extends the selection to the surrounding block and reads it. If used with "
+#~ "shift key, reduce the block and read it."
+#~ msgstr ""
+#~ "Estende a selección ao bloque do redor e leo. Se é usado ca tecla shift, "
+#~ "reduce o bloque e fálao."
+
+#~ msgid "Duplicates the current line and reads it"
+#~ msgstr "Duplica a liña actual e lea"
 
 #~ msgid ""
 #~ "An older version of this addon has been detected.\n"

--- a/readme-src.md
+++ b/readme-src.md
@@ -39,7 +39,7 @@ This addon creates an NVDA profile named "lambda" which is associated with the "
 
 If a previous profile with the same name is present in your system, the addon will not override it and you have to manually adjust your configuration profile. 
 
-To stave off this situation, if you have specific settings you'd like to preserve, you can use the "Revert LAMBDA Profile Wizard". The shortcut to start this tool is NVDA+alt+r.
+To stave off this situation, if you have specific settings you'd like to preserve, you can use the "Revert LAMBDA Profile Wizard". The shortcut to start this tool is NVDA+alt+r (when focused in LAMBDA).
 
 An easy option is also to delete old versions of the "lambda" profile after the installation of the addon. To do so, open the NVDA menu, select the "Configuration profiles" menu Item and press ENTER.
 


### PR DESCRIPTION
1. Updated Spanish localization and documentation.
2. Updated Galician documentation and localization.
3. clarified that the Reversion Wizard could only be opened while we have the foc on LAMBDA.

Any problem please comment.