### PR TITLE
Add usefull tips section to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ Due to a bug present in LAMBDA, the add-on provides an extra-logic that reports 
 * When words like "space", "spazio" "Espacio" etc. are inserted into the text, they may be reported by NVDA as the local NVDA language translation. 
 * Blank lines are not reported by the LAMBDA speech engine. The user will hear the translation of the word "space" instead. This could be both a blank line or a line containing only the word "space".
 
+## Usefull tips
+
+This is a set of tips that will help you on using the addon in a more eficient way.
+* Character-by-character reporting: Normally, when working with maths you would like NVDA to report things you're writing character by character. To do this, there are a couple of simple steps: ensure to have the foc on the LAMBDA's window or one of its variants (the six dots representation, for example); press NVDA+2 (number two) or navigate to NVDA menu>Preferences>Keyboard settings and check the box to Speak typed characters. And done, NVDA will speak written characters, but don't worry, only in LAMBDA or its special windows, the settings for the rest of applications will be left as they were.
+
 ## Addon mailing list:
 
 To report bugs, suggestions or if you want to contribute you can subscribe the Addon Google Group (in English).

--- a/readme-src.md
+++ b/readme-src.md
@@ -84,6 +84,11 @@ Due to a bug present in LAMBDA, the add-on provides an extra-logic that reports 
 * When words like "space", "spazio" "Espacio" etc. are inserted into the text, they may be reported by NVDA as the local NVDA language translation. 
 * Blank lines are not reported by the LAMBDA speech engine. The user will hear the translation of the word "space" instead. This could be both a blank line or a line containing only the word "space".
 
+## Usefull tips
+
+This is a set of tips that will help you on using the addon in a more eficient way.
+* Character-by-character reporting: Normally, when working with maths you would like NVDA to report things you're writing character by character. To do this, there are a couple of simple steps: ensure to have the foc on the LAMBDA's window or one of its variants (the six dots representation, for example); press NVDA+2 (number two) or navigate to NVDA menu>Preferences>Keyboard settings and check the box to Speak typed characters. And done, NVDA will speak written characters, but don't worry, only in LAMBDA or its special windows, the settings for the rest of applications will be left as they were.
+
 ## Addon mailing list:
 
 To report bugs, suggestions or if you want to contribute you can subscribe the Addon Google Group (in English).


### PR DESCRIPTION
José Enrique said me, and I think he was right, that there were any references on the documentation about tips or things that were not in de development, but that could be interesting for some type o users. In concrete, he said me that the documentation didn't contain references to the character by character reading. Salva also commented me that a few months ago (that a medium-level user couldn't discover the things by his own). So I thought appropriate to propose you a section containing tips as this. I think that people should know that if you modify certain settings when working with LAMBDA, it only afects the LAMBDA profile, and that it's an extended practice to want the character-by-character reading when working with mathematics.

What's your opinnion?