### PR TITLE
Enhance WXPython4 compatibility in Default Profile Reversion dialog

### DIFF
--- a/addon/appModules/lambda/lambdaProfileSetup.py
+++ b/addon/appModules/lambda/lambdaProfileSetup.py
@@ -137,22 +137,22 @@ class QuickProfileWizardDialog(SettingsDialog):
 		settingsSizer.Add(self.introStxt,flag=wx.BOTTOM)
 		# Translators: This is the label for a checkbox in the
 		# Quick Profile Wizard dialog.
-		self.defaultTranslationTableCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Keep the LAMBDA braille table for the current language (%s)") % TABLE_NAME)
+		self.defaultTranslationTableCheckBox=wx.CheckBox(self,wx.ID_ANY,label=_("Keep the LAMBDA braille table for the current language (%s)") % TABLE_NAME)
 		self.defaultTranslationTableCheckBox.SetValue(True)
 		settingsSizer.Add(self.defaultTranslationTableCheckBox,border=10,flag=wx.BOTTOM)
 		# Translators: This is the label for a checkbox in the
 		# Quick Profile Wizard dialog.
-		self.brailleTetherToFocusCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Set the braille cursor to tether the focus"))
+		self.brailleTetherToFocusCheckBox=wx.CheckBox(self,wx.ID_ANY,label=_("Set the braille cursor to tether the focus"))
 		self.brailleTetherToFocusCheckBox.SetValue(True)
 		settingsSizer.Add(self.brailleTetherToFocusCheckBox,border=10,flag=wx.BOTTOM)
 		# Translators: This is the label for a checkbox in the
 		# Quick Profile Wizard dialog.
-		self.disableReadByParagraphCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Disable the Braille reading by paragraph"))
+		self.disableReadByParagraphCheckBox=wx.CheckBox(self,wx.ID_ANY,label=_("Disable the Braille reading by paragraph"))
 		self.disableReadByParagraphCheckBox.SetValue(True)
 		settingsSizer.Add(self.disableReadByParagraphCheckBox,border=10,flag=wx.BOTTOM)
 		# Translators: This is the label for a checkbox in the
 		# Quick Profile Wizard dialog.
-		self.disableBrailleWordWrapCheckBox=wx.CheckBox(self,wx.NewId(),label=_("Disable word wrappping of the braille line"))
+		self.disableBrailleWordWrapCheckBox=wx.CheckBox(self,wx.ID_ANY,label=_("Disable word wrappping of the braille line"))
 		self.disableBrailleWordWrapCheckBox.SetValue(True)
 		settingsSizer.Add(self.disableBrailleWordWrapCheckBox,border=10,flag=wx.BOTTOM)
 

--- a/addon/appModules/lambda/lambdaProfileSetup.py
+++ b/addon/appModules/lambda/lambdaProfileSetup.py
@@ -11,6 +11,7 @@ import braille
 import addonHandler
 import sharedMessages as shMsg
 import gui
+from gui import guiHelper
 from gui.settingsDialogs import SettingsDialog
 import wx
 try :
@@ -131,30 +132,26 @@ class QuickProfileWizardDialog(SettingsDialog):
 	title = _("Revert LAMBDA Profile Wizard")
 
 	def makeSettings(self, settingsSizer):
+		helper=guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: This is the static text of the Quick Profile Wizard dialog.
 		msgIntro=_("Choose which options you want to reset to the default value for the Lambdas profile")
-		self.introStxt=wx.StaticText(self,-1,label=msgIntro)
-		settingsSizer.Add(self.introStxt,flag=wx.BOTTOM)
+		self.introStxt=helper.addItem(wx.StaticText(self,-1,label=msgIntro))
 		# Translators: This is the label for a checkbox in the
 		# Quick Profile Wizard dialog.
-		self.defaultTranslationTableCheckBox=wx.CheckBox(self,wx.ID_ANY,label=_("Keep the LAMBDA braille table for the current language (%s)") % TABLE_NAME)
+		self.defaultTranslationTableCheckBox=helper.addItem(wx.CheckBox(self,wx.ID_ANY,label=_("Keep the LAMBDA braille table for the current language (%s)") % TABLE_NAME))
 		self.defaultTranslationTableCheckBox.SetValue(True)
-		settingsSizer.Add(self.defaultTranslationTableCheckBox,border=10,flag=wx.BOTTOM)
 		# Translators: This is the label for a checkbox in the
 		# Quick Profile Wizard dialog.
-		self.brailleTetherToFocusCheckBox=wx.CheckBox(self,wx.ID_ANY,label=_("Set the braille cursor to tether the focus"))
+		self.brailleTetherToFocusCheckBox=helper.addItem(wx.CheckBox(self,wx.ID_ANY,label=_("Set the braille cursor to tether the focus")))
 		self.brailleTetherToFocusCheckBox.SetValue(True)
-		settingsSizer.Add(self.brailleTetherToFocusCheckBox,border=10,flag=wx.BOTTOM)
 		# Translators: This is the label for a checkbox in the
 		# Quick Profile Wizard dialog.
-		self.disableReadByParagraphCheckBox=wx.CheckBox(self,wx.ID_ANY,label=_("Disable the Braille reading by paragraph"))
+		self.disableReadByParagraphCheckBox=helper.addItem(wx.CheckBox(self,wx.ID_ANY,label=_("Disable the Braille reading by paragraph")))
 		self.disableReadByParagraphCheckBox.SetValue(True)
-		settingsSizer.Add(self.disableReadByParagraphCheckBox,border=10,flag=wx.BOTTOM)
 		# Translators: This is the label for a checkbox in the
 		# Quick Profile Wizard dialog.
-		self.disableBrailleWordWrapCheckBox=wx.CheckBox(self,wx.ID_ANY,label=_("Disable word wrappping of the braille line"))
+		self.disableBrailleWordWrapCheckBox=helper.addItem(wx.CheckBox(self,wx.ID_ANY,label=_("Disable word wrappping of the braille line")))
 		self.disableBrailleWordWrapCheckBox.SetValue(True)
-		settingsSizer.Add(self.disableBrailleWordWrapCheckBox,border=10,flag=wx.BOTTOM)
 
 	def postInit(self):
 		self.defaultTranslationTableCheckBox.SetFocus()

--- a/addon/appModules/lambda/lambdaProfileSetup.py
+++ b/addon/appModules/lambda/lambdaProfileSetup.py
@@ -132,25 +132,25 @@ class QuickProfileWizardDialog(SettingsDialog):
 	title = _("Revert LAMBDA Profile Wizard")
 
 	def makeSettings(self, settingsSizer):
-		helper=guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
+		sHelper=guiHelper.BoxSizerHelper(self, sizer=settingsSizer)
 		# Translators: This is the static text of the Quick Profile Wizard dialog.
 		msgIntro=_("Choose which options you want to reset to the default value for the Lambdas profile")
-		self.introStxt=helper.addItem(wx.StaticText(self,-1,label=msgIntro))
+		self.introStxt=sHelper.addItem(wx.StaticText(self,label=msgIntro))
 		# Translators: This is the label for a checkbox in the
 		# Quick Profile Wizard dialog.
-		self.defaultTranslationTableCheckBox=helper.addItem(wx.CheckBox(self,wx.ID_ANY,label=_("Keep the LAMBDA braille table for the current language (%s)") % TABLE_NAME))
+		self.defaultTranslationTableCheckBox=sHelper.addItem(wx.CheckBox(self,label=_("Keep the LAMBDA braille table for the current language (%s)") % TABLE_NAME))
 		self.defaultTranslationTableCheckBox.SetValue(True)
 		# Translators: This is the label for a checkbox in the
 		# Quick Profile Wizard dialog.
-		self.brailleTetherToFocusCheckBox=helper.addItem(wx.CheckBox(self,wx.ID_ANY,label=_("Set the braille cursor to tether the focus")))
+		self.brailleTetherToFocusCheckBox=sHelper.addItem(wx.CheckBox(self,label=_("Set the braille cursor to tether the focus")))
 		self.brailleTetherToFocusCheckBox.SetValue(True)
 		# Translators: This is the label for a checkbox in the
 		# Quick Profile Wizard dialog.
-		self.disableReadByParagraphCheckBox=helper.addItem(wx.CheckBox(self,wx.ID_ANY,label=_("Disable the Braille reading by paragraph")))
+		self.disableReadByParagraphCheckBox=sHelper.addItem(wx.CheckBox(self,label=_("Disable the Braille reading by paragraph")))
 		self.disableReadByParagraphCheckBox.SetValue(True)
 		# Translators: This is the label for a checkbox in the
 		# Quick Profile Wizard dialog.
-		self.disableBrailleWordWrapCheckBox=helper.addItem(wx.CheckBox(self,wx.ID_ANY,label=_("Disable word wrappping of the braille line")))
+		self.disableBrailleWordWrapCheckBox=sHelper.addItem(wx.CheckBox(self,label=_("Disable word wrappping of the braille line")))
 		self.disableBrailleWordWrapCheckBox.SetValue(True)
 
 	def postInit(self):

--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("This addon provides access to the Lambda math editor with both braille and speech support."),
 	# version
-	"addon_version" : "1.2.1a",
+	"addon_version" : "1.2.2-dev",
 	# Author(s)
 	"addon_author" : "Alberto Zanella, Ivan Novegil",
 	# URL for the add-on documentation support


### PR DESCRIPTION
In order to improve compatibility with WXPython 4, deprecated wx.NewId() has been changed to wx.ID_ANY on lambdaSetupProfile, as IDs are not relevant in this case.
In addition, the version in buildVars was updated from 1.2.1A to 1.2.2-dev.

If any problem please comment.