### PR TITLE
Update compatibility flags for NVDA 2021.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ You can subscribe from the website: <https://groups.io/g/lambda-nvda>.
 
 Below is a list of changes between the different add-on versions. Next to the version number, between parentheses, is the development status. The current development release isn't included as it could have changes until it is flagged as stable or discarded as candidate.
 
+### Version 1.3.1-dev (development)
+
+* Updated compatibility flags to reflect support for NVDA 2021.1.
+* New languages. Updated translations.
+
 ### Version 1.3.0 (stable)
 
 * Support for newer version of NVDA (Support for Python 3)

--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("This addon provides access to the Lambda math editor with both braille and speech support."),
 	# version
-	"addon_version" : "1.3.0",
+	"addon_version" : "1.3.1-dev",
 	# Author(s)
 	"addon_author" : "Alberto Zanella, Ivan Novegil",
 	# URL for the add-on documentation support
@@ -31,7 +31,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion" : "2017.3.0",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2019.3.1",
+	"addon_lastTestedNVDAVersion" : "2021.1.0",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel" : None,
 }

--- a/readme-src.md
+++ b/readme-src.md
@@ -103,6 +103,11 @@ You can subscribe from the website: <https://groups.io/g/lambda-nvda>.
 
 Below is a list of changes between the different add-on versions. Next to the version number, between parentheses, is the development status. The current development release isn't included as it could have changes until it is flagged as stable or discarded as candidate.
 
+### Version 1.3.1-dev (development)
+
+* Updated compatibility flags to reflect support for NVDA 2021.1.
+* New languages. Updated translations.
+
 ### Version 1.3.0 (stable)
 
 * Support for newer version of NVDA (Support for Python 3)


### PR DESCRIPTION
This pull requests creates a new development version, 1.3.1-dev, with updated compatibility flags up to NVDA 2021.1, since no issues where detected with NVDA 2021.1 Beta3 with the performed basic testing.
Please test and comment to release this version if it has no issues.