### PR TITLE
Prepare 1.3.2 release with declared NVDA 2022.1 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ You can subscribe from the website: <https://groups.io/g/lambda-nvda>.
 
 Below is a list of changes between the different add-on versions. Next to the version number, between parentheses, is the development status. The current development release isn't included as it could have changes until it is flagged as stable or discarded as candidate.
 
+### Version 1.3.2 (stable)
+
+* Updated compatibility flags to reflect support for NVDA 2022.1.
+* New languages. Updated translations.
+
 ### Version 1.3.1 (stable)
 
 * Updated compatibility flags to reflect support for NVDA 2021.1.

--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("This addon provides access to the Lambda math editor with both braille and speech support."),
 	# version
-	"addon_version" : "1.3.1",
+	"addon_version" : "1.3.2-dev",
 	# Author(s)
 	"addon_author" : "Alberto Zanella, Ivan Novegil",
 	# URL for the add-on documentation support
@@ -31,7 +31,7 @@ addon_info = {
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion" : "2017.3.0",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2021.1.0",
+	"addon_lastTestedNVDAVersion" : "2022.1.0",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel" : None,
 }

--- a/readme-src.md
+++ b/readme-src.md
@@ -103,6 +103,11 @@ You can subscribe from the website: <https://groups.io/g/lambda-nvda>.
 
 Below is a list of changes between the different add-on versions. Next to the version number, between parentheses, is the development status. The current development release isn't included as it could have changes until it is flagged as stable or discarded as candidate.
 
+### Version 1.3.2 (stable)
+
+* Updated compatibility flags to reflect support for NVDA 2022.1.
+* New languages. Updated translations.
+
 ### Version 1.3.1 (stable)
 
 * Updated compatibility flags to reflect support for NVDA 2021.1.


### PR DESCRIPTION
This PR adds the following changes:
1. Update version to 1.3.2-dev (I think the best option would be to change it to 1.3.2 after merge and release a stable version directly).
2. Update lastTestedNVDAVersion flag to 2022.1.0.
3. Add 1.3.2 (stable) to the changelog.

https://github.com/lambda-nvda/lambdaNvda/releases/download/dev/lambda-dev.nvda-addon